### PR TITLE
Extra settings to remove pads after delay

### DIFF
--- a/settings.json.template
+++ b/settings.json.template
@@ -334,6 +334,18 @@
   */
 
   /*
+   * Delete pads plugin configuration.
+   * npm i ep_delete_after_delay_lite
+   */
+
+  "ep_delete_after_delay_lite": {
+    "delay": 86400, // one day, in seconds
+    "loop": true,
+    "loopDelay": 3600, // one hour, in seconds
+    "deleteAtStart": true
+  },
+
+  /*
    * Toolbar buttons configuration.
    *
    * Uncomment to customize.


### PR DESCRIPTION
Changed the original npm package to better fit our scenario and published it as _ep_delete_after_delay_lite_.
```shell
npm i ep_delete_after_delay_lite
```